### PR TITLE
feat(devcontainer): add zizmor devcontainer feature

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,12 +16,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     esac \
     && curl -sL "https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-${HADOLINT_ARCH}" -o /usr/local/bin/hadolint \
     && chmod +x /usr/local/bin/hadolint \
-    && case ${ARCH} in \
-        "amd64") ZIZMOR_ARCH="x86_64-unknown-linux-gnu" ;; \
-        "arm64") ZIZMOR_ARCH="aarch64-unknown-linux-gnu" ;; \
-        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
-    esac \
-    && curl -sL "https://github.com/zizmorcore/zizmor/releases/latest/download/zizmor-${ZIZMOR_ARCH}.tar.gz" | tar -xz -C /usr/local/bin/ \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
 		"ghcr.io/devcontainers-extra/features/lefthook-asdf:1": {
 			"version": "latest"
 		},
-		"ghcr.io/michidk/devcontainers-features/typos:1": {}
+		"ghcr.io/michidk/devcontainers-features/typos:1": {},
+		"ghcr.io/jsburckhardt/devcontainer-features/zizmor:1": {}
 	},
 	"customizations": {
 	},


### PR DESCRIPTION
This pull request adds the devcontainer feature `ghcr.io/jsburckhardt/devcontainer-features/zizmor:1` to `.devcontainer/devcontainer.json`. This feature installs `zizmor` inside the development container, enabling static security analysis for GitHub Actions workflows.

---
*PR created automatically by Jules for task [3855660315240151196](https://jules.google.com/task/3855660315240151196) started by @9renpoto*